### PR TITLE
Fix N/A speed type error

### DIFF
--- a/better_ffmpeg_progress/better_ffmpeg_progress.py
+++ b/better_ffmpeg_progress/better_ffmpeg_progress.py
@@ -103,7 +103,7 @@ class FfmpegProcess:
                 elif "speed" in ffmpeg_output:
                     speed_str = value[:-1]
 
-                    if speed_str != "0" and "N/A" not in speed_str:
+                    if speed_str != "0" and "N/A" not in value:
                         self._speed = float(speed_str)
 
                         if self._can_get_duration:


### PR DESCRIPTION
Issue #21 

The N/A check is done after the last character is stripped off, so the code is looking for 'N/A' in the newly shortened 'N/'. This would simply check against the pre-shortened value