### PR TITLE
Add support for passing arbitrary file descriptors to the log

### DIFF
--- a/better_ffmpeg_progress/better_ffmpeg_progress.py
+++ b/better_ffmpeg_progress/better_ffmpeg_progress.py
@@ -93,7 +93,7 @@ class FfmpegProcess:
 
         self._ffmpeg_log_file = Path(
             ffmpeg_log_file or f"{self._input_filepath.name}_ffmpeg_log.txt"
-        )
+        ) if type(ffmpeg_log_file) is os.PathLike else ffmpeg_log_file
         self._print_detected_duration = print_detected_duration
         self._duration_secs = get_media_duration(input_file_path_str)
 
@@ -151,7 +151,22 @@ class FfmpegProcess:
         self._return_code = 1
 
         try:
-            with open(self._ffmpeg_log_file, "w", encoding="utf-8") as f:
+            if type(self._ffmpeg_log_file) is Path:
+                with open(self._ffmpeg_log_file, "w", encoding="utf-8") as f:
+                    creationflags = 0
+
+                    if os.name == "nt":
+                        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+
+                    self._process = subprocess.Popen(
+                        current_ffmpeg_command,
+                        shell=self._shell_needed,
+                        stdout=subprocess.PIPE,
+                        stderr=f,
+                        creationflags=creationflags,
+                    )
+            else:
+                # Assume it's a valid file descriptor like sys.stdout
                 creationflags = 0
 
                 if os.name == "nt":
@@ -161,7 +176,7 @@ class FfmpegProcess:
                     current_ffmpeg_command,
                     shell=self._shell_needed,
                     stdout=subprocess.PIPE,
-                    stderr=f,
+                    stderr=self._ffmpeg_log_file,
                     creationflags=creationflags,
                 )
         except Exception as e:

--- a/better_ffmpeg_progress/better_ffmpeg_progress.py
+++ b/better_ffmpeg_progress/better_ffmpeg_progress.py
@@ -93,7 +93,8 @@ class FfmpegProcess:
 
         self._ffmpeg_log_file = Path(
             ffmpeg_log_file or f"{self._input_filepath.name}_ffmpeg_log.txt"
-        ) if type(ffmpeg_log_file) is os.PathLike else ffmpeg_log_file
+        ) if (isinstance(ffmpeg_log_file, os.PathLike) or ffmpeg_log_file is None) else ffmpeg_log_file
+
         self._print_detected_duration = print_detected_duration
         self._duration_secs = get_media_duration(input_file_path_str)
 
@@ -151,7 +152,7 @@ class FfmpegProcess:
         self._return_code = 1
 
         try:
-            if type(self._ffmpeg_log_file) is Path:
+            if isinstance(self._ffmpeg_log_file, (str, Path)):
                 with open(self._ffmpeg_log_file, "w", encoding="utf-8") as f:
                     creationflags = 0
 

--- a/better_ffmpeg_progress/better_ffmpeg_progress.py
+++ b/better_ffmpeg_progress/better_ffmpeg_progress.py
@@ -57,7 +57,7 @@ class FfmpegProcess:
         self,
         command: List[str],
         ffmpeg_log_level: Optional[Union[FfmpegLogLevel, str]] = None,
-        ffmpeg_log_file: Optional[Union[str, Path]] = None,
+        ffmpeg_log_file: Optional[Union[str, os.PathLike]] = None,
         print_detected_duration: bool = False,
     ):
         # Raises FfmpegCommandError if the command is invalid
@@ -91,9 +91,12 @@ class FfmpegProcess:
         # Assumes last argument is output
         self._output_filepath = Path(command[-1])
 
-        self._ffmpeg_log_file = Path(
-            ffmpeg_log_file or f"{self._input_filepath.name}_ffmpeg_log.txt"
-        ) if (isinstance(ffmpeg_log_file, os.PathLike) or ffmpeg_log_file is None) else ffmpeg_log_file
+        if ffmpeg_log_file is None:
+            self._ffmpeg_log_file = Path(f"{self._input_filepath.name}_ffmpeg_log.txt")
+        elif isinstance(ffmpeg_log_file, (str, os.PathLike)):
+            self._ffmpeg_log_file = Path(ffmpeg_log_file)
+        else:
+            self._ffmpeg_log_file = ffmpeg_log_file
 
         self._print_detected_duration = print_detected_duration
         self._duration_secs = get_media_duration(input_file_path_str)
@@ -152,13 +155,13 @@ class FfmpegProcess:
         self._return_code = 1
 
         try:
-            if isinstance(self._ffmpeg_log_file, (str, Path)):
+            creationflags = 0
+            # Windows
+            if os.name == "nt":
+                creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+
+            if isinstance(self._ffmpeg_log_file, Path):
                 with open(self._ffmpeg_log_file, "w", encoding="utf-8") as f:
-                    creationflags = 0
-
-                    if os.name == "nt":
-                        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
-
                     self._process = subprocess.Popen(
                         current_ffmpeg_command,
                         shell=self._shell_needed,
@@ -167,12 +170,6 @@ class FfmpegProcess:
                         creationflags=creationflags,
                     )
             else:
-                # Assume it's a valid file descriptor like sys.stdout
-                creationflags = 0
-
-                if os.name == "nt":
-                    creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
-
                 self._process = subprocess.Popen(
                     current_ffmpeg_command,
                     shell=self._shell_needed,


### PR DESCRIPTION
This pull request improves the flexibility of how FFmpeg log output is handled in the `better_ffmpeg_progress.py` module. The main change allows the log destination to be either a file path or a file-like object, such as `sys.stdout`, making it easier to redirect FFmpeg logs for different use cases.

**FFmpeg log output handling improvements:**

* Updated the initialization of `self._ffmpeg_log_file` in `__init__` to support both `os.PathLike` objects and direct file-like objects, enabling the use of custom log destinations.
* Modified the `run` method to check the type of `self._ffmpeg_log_file` and handle writing to either a file path or a file descriptor (e.g., `sys.stdout`). This ensures compatibility with various logging scenarios. [[1]](diffhunk://#diff-6a67f7de23295b2fbf8da12ce82dcd6fa297484cd88dfeb86bdbb851d33c72f0R155) [[2]](diffhunk://#diff-6a67f7de23295b2fbf8da12ce82dcd6fa297484cd88dfeb86bdbb851d33c72f0R169-R182)